### PR TITLE
optional msgpack dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.0 : TBD
+
+- **Change**: Msgpack dependency is no longer required.
+
 ## 0.7.1 : 13.04.2020
 
 - **Change** Use [poetry](https://python-poetry.org/) instead of [pipenv](https://github.com/pypa/pipenv)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ pipenv install django-api-forms
 python setup.py install
 ```
 
+Optional:
+```shell script
+# msgpack support
+pipenv install msgpack
+```
+
 ## Example
 
 **Simple nested JSON request**
@@ -160,6 +166,17 @@ If you want example with whole Django project, check out repository created by @
 [django_api_forms_modelchoicefield_example](https://github.com/pawl/django_api_forms_modelchoicefield_example), where
 he uses library with
 [ModelChoiceField](https://docs.djangoproject.com/en/3.0/ref/forms/fields/#django.forms.ModelChoiceField).
+
+
+## Running Tests
+
+```shell script
+# install all dependencies
+poetry install
+
+# run the tests
+poetry run pytest
+```
 
 ---
 Made with ❤️ and ☕️ by Jakub Dubec & [BACKBONE s.r.o.](https://www.backbone.sk/en/)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ python setup.py install
 
 Optional:
 ```shell script
-# msgpack support
+# msgpack support (for requests with Content-Type: application/x-msgpack)
 pipenv install msgpack
 ```
 

--- a/django_api_forms/exceptions.py
+++ b/django_api_forms/exceptions.py
@@ -1,6 +1,11 @@
 from typing import Union
 
 
+class UnsupportedMediaType(Exception):
+    """Unable to parse the request (based on the Content-Type)"""
+    pass
+
+
 class RequestValidationError(Exception):
     def __init__(self, errors: Union[list, dict], code=None, params=None):
         super().__init__(errors, code, params)

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,10 @@
 import os
+
 from setuptools import setup
 
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
-REQUIRED = [
-    'Django>=2.0',
-    'msgpack'
-]
+REQUIRED = ['Django>=2.0']
 
 
 def read_files(files):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,0 +1,60 @@
+import json
+
+import msgpack
+from django.test import TestCase
+from django.test.client import RequestFactory
+from django_api_forms import Form
+from django_api_forms.exceptions import UnsupportedMediaType
+
+
+class FormTests(TestCase):
+    def test_create_from_request(self):
+        # TEST: Form.create_from_request with VALID JSON data
+        request_factory = RequestFactory()
+        valid_test_data = {'message': ['turned', 'into', 'json']}
+        request = request_factory.post(
+            '/test/',
+            data=valid_test_data,
+            content_type='application/json')
+        form = Form.create_from_request(request)
+        self.assertEqual(form._data, valid_test_data)
+
+        # TEST: Form.create_from_request with INVALID JSON data
+        request_factory = RequestFactory()
+        invalid_test_data = '[1, 2,'
+        request = request_factory.post(
+            '/test/',
+            data=invalid_test_data,
+            content_type='application/json')
+        with self.assertRaises(json.JSONDecodeError):
+            form = Form.create_from_request(request)
+
+        # TEST: Form.create_from_request with VALID msgpack data
+        request_factory = RequestFactory()
+        valid_test_data = [1, 2, 3]
+        packed_valid_test_data = msgpack.packb(valid_test_data)
+        request = request_factory.post(
+            '/test/',
+            data=packed_valid_test_data,
+            content_type='application/x-msgpack')
+        form = Form.create_from_request(request)
+        self.assertEqual(form._data, valid_test_data)
+
+        # TEST: Form.create_from_request with INVALID msgpack data
+        request_factory = RequestFactory()
+        invalid_test_data = 'invalid msgpack'
+        request = request_factory.post(
+            '/test/',
+            data=invalid_test_data,
+            content_type='application/x-msgpack')
+        with self.assertRaises(msgpack.exceptions.ExtraData):
+            form = Form.create_from_request(request)
+
+        # TEST: Form.create_from_request with unsupported content_type
+        request_factory = RequestFactory()
+        request = request_factory.post(
+            '/test/',
+            data='blah',
+            content_type='blah')
+        with self.assertRaises(UnsupportedMediaType):
+            form = Form.create_from_request(request)


### PR DESCRIPTION
This PR makes the msgpack dependency optional for projects that don't intend to use msgpack.

Here's an overview of what I did:
* Added a mapping of content types to parsers, so I could optionally add msgpack to it (if it's installed).
* Changed `Form.create_from_request` to try to get the appropriate parser from the new mapping (based on content type).
* Added a custom exception for unexpected content types (called `UnsupportedMediaType`, like the 415 HTTP status code, DRF does something similar). This might be unnecessary. I was thinking a custom exception would make it easier to test for this specific scenario, since `RuntimeError` could theoretically be thrown during parsing too. 
* Removed `msgpack` from REQUIRED in setup.py and added a note about optionally installing it in the readme.
* Added a `test_forms.py` and added some basic tests for `Form.create_from_request`.
* Added some docs on how to run tests.
* Used isort on django_api_forms/forms.py. This is why some imports got sorted alphabetically.