### PR TITLE
use DeclarativeFieldsMetaclass from django

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.8.0 : TBD
 
+- **Change**: Remove DeclarativeFieldsMetaclass and import from Django instead.
 - **Change**: Msgpack dependency is no longer required.
 
 ## 0.7.1 : 13.04.2020

--- a/django_api_forms/forms.py
+++ b/django_api_forms/forms.py
@@ -4,7 +4,8 @@ from collections import OrderedDict
 from typing import Union
 
 from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
-from django.forms import Field, MediaDefiningClass
+from django.forms import Field
+from django.forms.forms import DeclarativeFieldsMetaclass
 from django.utils.translation import gettext as _
 
 from .exceptions import RequestValidationError, UnsupportedMediaType
@@ -19,43 +20,6 @@ except ImportError:
 parsers_by_content_type = {'application/json': json.loads}
 if is_msgpack_installed:
     parsers_by_content_type['application/x-msgpack'] = msgpack.loads
-
-
-class DeclarativeFieldsMetaclass(MediaDefiningClass):
-    """Collect Fields declared on the base classes."""
-
-    def __new__(mcs, name, bases, attrs):
-        # Collect fields from current class.
-        current_fields = []
-        for key, value in list(attrs.items()):
-            if isinstance(value, Field):
-                current_fields.append((key, value))
-                attrs.pop(key)
-        attrs['declared_fields'] = OrderedDict(current_fields)
-
-        new_class = super(DeclarativeFieldsMetaclass, mcs).__new__(mcs, name, bases, attrs)
-
-        # Walk through the MRO.
-        declared_fields = OrderedDict()
-        for base in reversed(new_class.__mro__):
-            # Collect fields from base class.
-            if hasattr(base, 'declared_fields'):
-                declared_fields.update(base.declared_fields)
-
-            # Field shadowing.
-            for attr, value in base.__dict__.items():
-                if value is None and attr in declared_fields:
-                    declared_fields.pop(attr)
-
-        new_class.base_fields = declared_fields
-        new_class.declared_fields = declared_fields
-
-        return new_class
-
-    @classmethod
-    def __prepare__(metacls, name, bases, **kwds):
-        # Remember the order in which form fields are defined.
-        return OrderedDict()
 
 
 class BaseForm(object):


### PR DESCRIPTION
It looks like `DeclarativeFieldsMetaclass` matches the one in django: https://github.com/django/django/blob/stable/2.2.x/django/forms/forms.py#L25-L58

This PR removes `DeclarativeFieldsMetaclass` and uses the one from Django so there's less code to test.