### PR TITLE
move error messages to default_error_messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.9.0 : TBD
+
+- **Change**: Moved field error messages to default_error_messages for easier overriding and testing.
+- **Fix**: Fix KeyError when invalid values are sent to FieldList.
+- **Fix**: Removed unnecessary error checking in FieldList.
+
+
 ## 0.8.0 : 05.05.2020
 
 - **Maintenance**: Add tests for fields

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -273,9 +273,9 @@ class FormFieldListTests(SimpleTestCase):
 
 class EnumFieldTests(SimpleTestCase):
     class Color(Enum):
-            RED = 1
-            GREEN = 2
-            BLUE = 3
+        RED = 1
+        GREEN = 2
+        BLUE = 3
 
     def test_enumfield_init(self):
         # TEST: initialize EnumField with an instance of Enum


### PR DESCRIPTION
This PR mainly moves all the field error message strings onto the Field classes using default_error_messages. This makes the messages easier to override if you're subclassing fields and helps clean up the tests a bit.

Fixed some other stuff too:
* removed a duplicated check in FieldList for whether the `self._field` is a Field (this already gets checked on init)
* fixed an unexpected KeyError when you pass truthy non-list values (invalid input) to FieldList
* typo: "have to be" -> "needs to be" in error messages 