### PR TITLE
cleanup python 2 syntax

### DIFF
--- a/django_api_forms/fields.py
+++ b/django_api_forms/fields.py
@@ -267,7 +267,7 @@ class ImageField(FileField):
     }
 
     def to_python(self, value) -> typing.Optional[File]:
-        f = super(ImageField, self).to_python(value)
+        f = super().to_python(value)
 
         if f is None:
             return None

--- a/django_api_forms/forms.py
+++ b/django_api_forms/forms.py
@@ -12,7 +12,7 @@ from .settings import Settings
 from .utils import resolve_from_path
 
 
-class BaseForm(object):
+class BaseForm:
     def __init__(self, data=None, request=None, settings: Settings = None):
         if data is None:
             self._data = {}
@@ -44,7 +44,7 @@ class BaseForm(object):
             field = self.fields[name]
         except KeyError:
             raise KeyError(
-                "Key '%s' not found in '%s'. Choices are: %s." % (
+                "Key '{}' not found in '{}'. Choices are: {}.".format(
                     name,
                     self.__class__.__name__,
                     ', '.join(sorted(self.fields)),


### PR DESCRIPTION
As mentioned in the title, I have updated the python syntax to version 3+ since the python version was pinned to [3.8](https://github.com/Sibyx/django_api_forms/blob/9547fbe2cd75f3777af9d7b8e7feca1e350d948b/pyproject.toml#L51).